### PR TITLE
add security for calls to claude, use PAT instead of github token for commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This GitHub Action integrates Claude Code in your GitHub workflows, enabling AI-
 
 ### 1. Add Claude to Your Repository
 
-Create two simple workflow files to integrate Claude with your repository:
+Create a workflow file to integrate Claude with your repository:
 
 **File: `.github/workflows/claude-code.yml`**
 ```yaml

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ on:
 
 jobs:
   claude-integration:
-    uses: fractureinc/claude-code-github-action/.github/workflows/claude-full.yml@v0.5.6
+    uses: fractureinc/claude-code-github-action/.github/workflows/claude-full.yml@v0.6.0
     with:
       issue-label: 'claude-fix'  # Optional: customize the trigger label
     secrets:
@@ -47,7 +47,7 @@ on:
 
 jobs:
   claude-label-fix:
-    uses: fractureinc/claude-code-github-action/.github/workflows/claude-label-fix.yml@v0.5.6
+    uses: fractureinc/claude-code-github-action/.github/workflows/claude-label-fix.yml@v0.6.0
     with:
       issue-label: 'claude-fix'  # Must match your chosen label
     secrets:
@@ -97,15 +97,18 @@ The reusable workflows support several configuration options:
 ```yaml
 jobs:
   claude-integration:
-    uses: fractureinc/claude-code-github-action/.github/workflows/claude-full.yml@v0.5.6
+    uses: fractureinc/claude-code-github-action/.github/workflows/claude-full.yml@v0.6.0
     with:
       # All parameters are optional with sensible defaults
-      issue-label: 'claude-fix'  # Label that triggers issue fixes
-      branch-prefix: 'fix'       # Prefix for branches created by fixes
-      debug-mode: false          # Enable verbose logging
-      strict-mode: true          # When false, allows Claude to add improvements
+      issue-label: 'claude-fix'    # Label that triggers issue fixes
+      branch-prefix: 'fix'         # Prefix for branches created by fixes
+      require-org-membership: true # Only process issues from org members
+      organization: 'my-org'       # Organization to check membership against
+      debug-mode: false            # Enable verbose logging
+      strict-mode: true            # When false, allows Claude to add improvements
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}  # Optional: For commit attribution
 ```
 
 ### Label-Based Integration (`claude-label-fix.yml`)
@@ -113,14 +116,17 @@ jobs:
 ```yaml
 jobs:
   claude-label-fix:
-    uses: fractureinc/claude-code-github-action/.github/workflows/claude-label-fix.yml@v0.5.6
+    uses: fractureinc/claude-code-github-action/.github/workflows/claude-label-fix.yml@v0.6.0
     with:
       # All parameters are optional with sensible defaults
-      issue-label: 'claude-fix'  # Must match the label you're using
-      branch-prefix: 'fix'       # Prefix for branches created by fixes
-      debug-mode: false          # Enable verbose logging
+      issue-label: 'claude-fix'    # Must match the label you're using
+      branch-prefix: 'fix'         # Prefix for branches created by fixes
+      require-org-membership: true # Only process issues from org members
+      organization: 'my-org'       # Organization to check membership against
+      debug-mode: false            # Enable verbose logging
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}  # Optional: For commit attribution
 ```
 
 Only repo maintainers with write access can add labels, providing security control over which issues Claude will fix.
@@ -145,6 +151,9 @@ When using our reusable workflows, you only need to configure a few key options:
 |-----------|-------------|---------|---------|
 | `issue-label` | Label that triggers issue fixes | `claude-fix` | Both workflows |
 | `branch-prefix` | Prefix for branches created by fixes | `fix` | Both workflows |
+| `require-org-membership` | Require the issue creator to be an organization member | `true` | Both workflows |
+| `organization` | Organization name to check membership against | Repository owner | Both workflows |
+| `personal-access-token` | Token for commits to override the default GitHub token | None | Both workflows |
 | `debug-mode` | Enable verbose logging | `false` | Both workflows |
 | `strict-mode` | Controls whether Claude adds improvements beyond what's requested | `true` | Comment workflow only |
 
@@ -152,7 +161,7 @@ All parameters are optional and have sensible defaults.
 
 ## Enhanced Context for Claude
 
-With version 0.5.6, Claude now receives complete context for your PRs and issues, including:
+With version 0.6.0, Claude now receives complete context for your PRs and issues, including:
 
 - PR metadata (title, description, branch info)
 - Issue details (title, description, labels)
@@ -211,6 +220,8 @@ permissions:
 - Only users with appropriate GitHub permissions can trigger Claude Code actions
 - For issue fixes, using the label-based approach gives you more control over who can trigger code changes
 - The `strict-mode` parameter limits Claude to only making requested changes
+- The `require-org-membership` option ensures only organization members can use Claude for issues
+- Using a personal access token for commits ensures proper attribution and bypasses CLA requirements
 
 ## License
 

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,13 @@ inputs:
     description: 'Label that triggers issue fix workflows'
     required: false
     default: 'claude-fix'
+  require-org-membership:
+    description: 'Whether to require the issue creator to be an organization member to process the issue'
+    required: false
+    default: 'true'
+  organization:
+    description: 'The GitHub organization name to check membership against (defaults to the repo owner)'
+    required: false
   debug-mode:
     description: 'Enable full debug mode with shell tracing and Claude debug output'
     required: false
@@ -55,6 +62,9 @@ inputs:
   github-token:
     description: 'GitHub token for API access'
     required: true
+  personal-access-token:
+    description: 'Optional personal access token for commits, to override the default GitHub token'
+    required: false
   output-file:
     description: 'Path to write the output to (for direct mode)'
     required: false
@@ -111,11 +121,11 @@ runs:
       shell: bash
       run: |
         chmod +x ${{ github.action_path }}/scripts/issue-fix-mode.sh
-        ${{ github.action_path }}/scripts/issue-fix-mode.sh "${{ inputs.issue-number }}" "${{ inputs.repo-owner }}" "${{ inputs.repo-name }}" "${{ inputs.branch-prefix }}" "${{ inputs.anthropic-api-key }}" "${{ inputs.github-token }}" "${{ inputs.issue-label }}" "${{ inputs.debug-mode }}" "${{ inputs.feedback }}"
+        ${{ github.action_path }}/scripts/issue-fix-mode.sh "${{ inputs.issue-number }}" "${{ inputs.repo-owner }}" "${{ inputs.repo-name }}" "${{ inputs.branch-prefix }}" "${{ inputs.anthropic-api-key }}" "${{ inputs.github-token }}" "${{ inputs.issue-label }}" "${{ inputs.debug-mode }}" "${{ inputs.feedback }}" "${{ inputs.require-org-membership }}" "${{ inputs.organization }}" "${{ inputs.personal-access-token }}"
         
     - name: Process Issue Analysis
       if: inputs.mode == 'issue-analyze'
       shell: bash
       run: |
         chmod +x ${{ github.action_path }}/scripts/issue-analyze-mode.sh
-        ${{ github.action_path }}/scripts/issue-analyze-mode.sh "${{ inputs.issue-number }}" "${{ inputs.repo-owner }}" "${{ inputs.repo-name }}" "${{ inputs.anthropic-api-key }}" "${{ inputs.github-token }}" "${{ inputs.debug-mode }}" "${{ inputs.feedback }}"
+        ${{ github.action_path }}/scripts/issue-analyze-mode.sh "${{ inputs.issue-number }}" "${{ inputs.repo-owner }}" "${{ inputs.repo-name }}" "${{ inputs.anthropic-api-key }}" "${{ inputs.github-token }}" "${{ inputs.debug-mode }}" "${{ inputs.feedback }}" "${{ inputs.require-org-membership }}" "${{ inputs.organization }}"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-github-action",
-  "version": "0.5.6",
+  "version": "0.6.0",
   "description": "GitHub action for Claude Code Integration in PR comments, reviews, inline code suggestions, and issue-based fixes",
   "main": "index.js",
   "scripts": {

--- a/scripts/issue-analyze-mode.sh
+++ b/scripts/issue-analyze-mode.sh
@@ -10,6 +10,8 @@ ANTHROPIC_API_KEY=$4
 GITHUB_TOKEN=$5
 DEBUG_MODE=${6:-"false"}
 FEEDBACK=$7
+REQUIRE_ORG_MEMBERSHIP=${8:-"true"}
+ORGANIZATION=${9:-$REPO_OWNER}
 
 # Enable debug mode if requested
 if [[ "$DEBUG_MODE" == "true" ]]; then
@@ -92,7 +94,7 @@ else
   FULL_REPO="$REPO_OWNER/$REPO_NAME"
 fi
 echo "Using repository: $FULL_REPO"
-if ! ISSUE_DETAILS=$(gh issue view $ISSUE_NUMBER --repo "$FULL_REPO" --json title,body,labels); then
+if ! ISSUE_DETAILS=$(gh issue view $ISSUE_NUMBER --repo "$FULL_REPO" --json title,body,labels,author); then
   echo "Error fetching issue details"
   exit 1
 fi
@@ -101,6 +103,39 @@ fi
 ISSUE_TITLE=$(echo "$ISSUE_DETAILS" | jq -r '.title')
 ISSUE_BODY=$(echo "$ISSUE_DETAILS" | jq -r '.body')
 ISSUE_LABELS=$(echo "$ISSUE_DETAILS" | jq -r '.labels[].name' | tr '\n' ',' | sed 's/,$//' || echo "none")
+ISSUE_AUTHOR=$(echo "$ISSUE_DETAILS" | jq -r '.author.login')
+
+# Check if user is a member of the organization if required
+if [[ "$REQUIRE_ORG_MEMBERSHIP" == "true" ]]; then
+  echo "Checking if $ISSUE_AUTHOR is a member of organization $ORGANIZATION"
+  ORG_CHECK=$(gh api -X GET /orgs/$ORGANIZATION/members/$ISSUE_AUTHOR --silent -i || true)
+  STATUS_CODE=$(echo "$ORG_CHECK" | head -n 1 | cut -d' ' -f2)
+  
+  if [[ "$STATUS_CODE" != "204" ]]; then
+    echo "User $ISSUE_AUTHOR is not a member of organization $ORGANIZATION. Skipping Claude analysis."
+    
+    # Leave a comment on the issue explaining why the analysis is skipped
+    ISSUE_COMMENT=$(cat <<EOF
+# Claude Code Analysis Skipped
+
+Sorry, Claude Code can only analyze issues created by organization members.
+
+This is to prevent API usage from users outside the organization.
+
+---
+🤖 Generated with Claude Code GitHub Action
+EOF
+)
+    
+    echo "Adding comment to issue #$ISSUE_NUMBER explaining why analysis was skipped"
+    gh issue comment "$ISSUE_NUMBER" --repo "$FULL_REPO" --body "$ISSUE_COMMENT"
+    
+    echo "Exiting due to non-organization member request"
+    exit 0
+  else
+    echo "User $ISSUE_AUTHOR is a member of organization $ORGANIZATION. Proceeding with Claude analysis."
+  fi
+fi
 
 # Create prompt for Claude
 CLAUDE_PROMPT=$(cat <<EOF


### PR DESCRIPTION
### Organization Membership Check
- Added verification of organization membership for issue requests
- Prevents API usage from random internet users
- Configurable with `require-org-membership` and `organization` parameters
- Default setting requires membership but can be disabled

### Personal Access Token Support
- Added support for using a personal access token for commits
- Enables proper attribution in contributor graphs
- Bypasses CLA requirements when using personal credentials
- Set via the new `personal-access-token` parameter

## Documentation
- Updated README with new parameters
- Added example configurations for both features
- Added security considerations section
